### PR TITLE
fix typo in administrative regions of Russia

### DIFF
--- a/data/subdivision-codes.csv
+++ b/data/subdivision-codes.csv
@@ -3498,7 +3498,7 @@ RU,AD,"Adygeya, Respublika"
 RU,AL,"Altay, Respublika"
 RU,ALT,Altayskiy kray
 RU,AMU,Amurskaya oblast'
-RU,ARK,"Arkhangel'skaya oblast,"
+RU,ARK,"Arkhangel'skaya oblast"
 RU,AST,Astrakhanskaya oblast'
 RU,BA,"Bashkortostan, Respublika"
 RU,BEL,Belgorodskaya oblast'
@@ -3517,7 +3517,7 @@ RU,KB,Kabardino-Balkarskaya Respublika
 RU,KC,Karachayevo-Cherkesskaya Respublika
 RU,KDA,Krasnodarskiy kray
 RU,KEM,Kemerovskaya oblast'
-RU,KGD,"Kaliningradskaya oblast,"
+RU,KGD,"Kaliningradskaya oblast"
 RU,KGN,Kurganskaya oblast'
 RU,KHA,Khabarovskiy kray
 RU,KHM,Khanty-Mansiyskiy avtonomnyy okrug


### PR DESCRIPTION
RU,ARK,"Arkhangel'skaya oblast," to RU,ARK,"Arkhangel'skaya oblast"
RU,KGD,"Kaliningradskaya oblast," to RU,KGD,"Kaliningradskaya oblast"

Source: https://www.iso.org/obp/ui/#iso:code:3166:RU