### PR TITLE
Enclose curly braces into backticks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To build the dataset we use the csv version of the current edition.
 
 Tools needed: [MDBTools](http://mdbtools.sourceforge.net/) and [CSVKit](https://github.com/onyxfish/csvkit).
 Download the current edition from [UNECE](https://www.unece.org/cefact/codesfortrade/codes_index.html) and put it into the root directory.
-Then execute ```bash scripts/prepare_edition_mdb.sh loc{ed}mdb.zip```, where {ed} identify the release.
+Then execute ```bash scripts/prepare_edition_mdb.sh loc{ed}mdb.zip```, where `{ed}` identify the release.
 
 To integrate the data from the csv then run the python file
 


### PR DESCRIPTION
This hopefully should fix MDX parser error in DataHub which is causing 500 error.

In MDX (especially with Next.js / next-mdx-remote), any {} inside your text can be interpreted as a JavaScript expression, which is why we’re seeing ReferenceError: ed is not defined.