### PR TITLE
Add has_solutions metadata

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -209,5 +209,10 @@
       }
     }
   ],
-  "collection": "logistics-data"
+  "collection": "logistics-data",
+  "has_solutions": [
+    "global-country-region-reference-data",
+    "logistics",
+    "worldwide-postal-code-database"
+  ]
 }


### PR DESCRIPTION
Adds `has_solutions` metadata in `datapackage.json` indicating which DataHub Solution package(s) this dataset belongs to:

- global-country-region-reference-data
- logistics
- worldwide-postal-code-database